### PR TITLE
Se acomoda color texto 3d de catarata

### DIFF
--- a/src/pages/cataratas/que-es-catarata/texts/Text3DCatarata.jsx
+++ b/src/pages/cataratas/que-es-catarata/texts/Text3DCatarata.jsx
@@ -20,9 +20,10 @@ const Text3DCatarata = ({ title, position }) => {
     >
       {title}
       <meshStandardMaterial
-        color="#B28F00"
-        roughness={0.3}
-        metalness={0.1}
+        color="#7d4fa3"
+        emissive="#000000"
+        roughness={10}
+        metalness={0.3}
         flatShading={true}
       />
 


### PR DESCRIPTION
This pull request updates the appearance of the 3D text in the `Text3DCatarata` component by modifying its material properties.

### Visual appearance changes:

* [`src/pages/cataratas/que-es-catarata/texts/Text3DCatarata.jsx`](diffhunk://#diff-00694115e901e4844ff310fd3c65d0c1b94e141406fe13d87d96ef5a5f98223eL23-R26): Updated the `meshStandardMaterial` properties in the `Text3DCatarata` component. The `color` was changed from `#B28F00` to `#7d4fa3`, `roughness` was increased from `0.3` to `10`, `metalness` was increased from `0.1` to `0.3`, and an `emissive` property with a value of `#000000` was added. These changes adjust the material's color, reflectivity, and shading for a different visual effect.